### PR TITLE
Use default event for 'javascript:' links

### DIFF
--- a/src/content/end.js
+++ b/src/content/end.js
@@ -902,16 +902,22 @@ class Course extends Logged {
         while (target.getAttribute('href') == null) {
             target = target.parentElement
         }
-        this.getTaskGroups(target.getAttribute('href'))
-        event.preventDefault()
-        event.stopPropagation()
-        return false
+        // only prevent default action if anything
+        // is going to be done with the link
+        if (this.getTaskGroups(target.getAttribute('href'))) {
+            event.preventDefault()
+            event.stopPropagation()
+            return false
+        }
     }
 
     getTaskGroups(link) {
         if (link.includes('Results')) {
             window.location.assign(link)
-            return
+            return true
+        }
+        if (link.includes('javascript:')) {
+            return false
         }
         Course.displaySpinner()
         fetch(link).then(e => {
@@ -925,6 +931,7 @@ class Course extends Logged {
                 window.location.assign(link)
                 Course.hideSpinner()
             })
+        return true
     }
 
     static hideSpinner() {


### PR DESCRIPTION
Fixes #25 .

This solutions disables the use of `event.preventDefault()` and `event.stopPropagation()` for 'javascript:' links which fixes the bizarre bug in Mozilla Firefox that stops them from working (but only on Progtest and only in JS code, not in the developer console or on other sites).

This fix was briefly tested on a mock exam link on both Mozilla Firefox 75.0 (x64) and Chromium 81.0.4044.113 (x64), but due to the link only being a mock (I already completed the test), additional testing may be required once another exam rolls around.