### PR TITLE
Fix notifications in Firefox

### DIFF
--- a/src/content/end.js
+++ b/src/content/end.js
@@ -191,7 +191,7 @@ class Logged {
     }
 
     static async taskSpider() {
-        let main = await fetch("/index.php?X=Main")
+        let main = await fetch(new URL('index.php?X=Main', 'https://' + window.location.hostname))
         if (!main.ok || main.redirected) { return [] }
 
         let mainText = await main.text()

--- a/src/content/end.js
+++ b/src/content/end.js
@@ -191,7 +191,7 @@ class Logged {
     }
 
     static async taskSpider() {
-        let main = await fetch(new URL('index.php?X=Main', 'https://' + window.location.hostname))
+        let main = await fetch(new URL('index.php?X=Main', window.location.protocol + '//' + window.location.hostname))
         if (!main.ok || main.redirected) { return [] }
 
         let mainText = await main.text()


### PR DESCRIPTION
This PR fixes notifications in Firefox.

Before this, they wouldn't get saved, as the fetch request would throw an exception (as it thought the URL was of an invalid format).

Generating the URL from the hostname and the `index.php` path fixes this issue and makes notifications work on both Mozilla Firefox 75.0 and Chromium 81.0.4044.113 (on Arch Linux).