### PR TITLE
Get subject page links from Courses

### DIFF
--- a/manifests/chrome.json
+++ b/manifests/chrome.json
@@ -36,6 +36,7 @@
         "webRequest",
         "webRequestBlocking",
         "*://progtest.fit.cvut.cz/*",
+        "*://courses.fit.cvut.cz/*",
         "storage",
         "tabs"
     ],

--- a/manifests/debug.json
+++ b/manifests/debug.json
@@ -26,6 +26,7 @@
         "webRequestBlocking",
         "*://progtest.fit.cvut.cz/*",
         "*://ptmock.localhost/*",
+        "*://courses.fit.cvut.cz/*",
         "storage",
         "tabs"
     ],

--- a/manifests/firefox.json
+++ b/manifests/firefox.json
@@ -36,6 +36,7 @@
         "webRequest",
         "webRequestBlocking",
         "*://progtest.fit.cvut.cz/*",
+        "*://courses.fit.cvut.cz/*",
         "storage",
         "tabs"
     ],

--- a/src/content/end.js
+++ b/src/content/end.js
@@ -287,7 +287,10 @@ class Main extends Logged {
 
     constructor() {
         super()
+        this.orderC = 1000
+    }
 
+    async initialise() {
         const subjects = document.createElement('div')
         subjects.classList.add('subjectSelect')
 
@@ -295,8 +298,15 @@ class Main extends Logged {
         settings.classList.add('subjectSelect')
         settings.classList.add('mainInfo');
 
-        this.orderC = 1000
         let orders = {}
+        
+        // get subject URLs from courses
+        const subjectInfo = await fetch("https://courses.fit.cvut.cz/data/courses-all.json", {
+            method: 'GET',
+            mode: 'cors',
+            credentials: 'omit'
+        }).then(response => response.json())
+            .catch(error => console.error(error))
 
         // collect all elements
         Main.getSubjects().forEach(e => {
@@ -309,17 +319,12 @@ class Main extends Logged {
                 push = settings
             ] = Main.parseSettings(e[2]) || this.parseSubject(e[2], e[0]).concat(subjects)
             orders[order] = footer
-            let link = {
-                "BI-AAG": "https://courses.fit.cvut.cz/BI-AAG/",
-                "BI-AG1": "https://courses.fit.cvut.cz/BI-AG1/",
-                "BI-OSY": "https://courses.fit.cvut.cz/BI-OSY/",
-                "BI-PA1": "https://moodle-vyuka.cvut.cz/course/view.php?id=2203",
-                "BI-PA2": "https://courses.fit.cvut.cz/BI-PA2/",
-                "BI-PJV": "https://moodle-vyuka.cvut.cz/course/view.php?id=2265",
-                "BI-PS1": "https://courses.fit.cvut.cz/BI-PS1/",
-                "BI-PYT": "https://courses.fit.cvut.cz/BI-PYT/",
-                "unknown": "https://courses.fit.cvut.cz/",
-            }[e[2]]
+
+            let link = null
+            try {
+                link = subjectInfo["courses"][e[2]]["homepage"]
+            } catch (_) {}
+            
             push.innerHTML += `
 <a href="${e[1]}" class="subject" style="order: ${order}" pttorder="${order}">
     <div class="subject-title">${e[2]}</div>
@@ -1140,6 +1145,7 @@ const preload = () => {
                 break
             case "Main":
                 parser = new Main()
+                parser.initialise()
                 break
             default: {
                 // determine if site is really main
@@ -1153,7 +1159,10 @@ const preload = () => {
 
         }
     }
-    else { parser = new Main() }
+    else {
+        parser = new Main()
+        parser.initialise()
+    }
 }
 
 if (!settingsLoaded) { window.addEventListener('ppt-loaded', preload) }

--- a/src/content/end.js
+++ b/src/content/end.js
@@ -306,7 +306,6 @@ class Main extends Logged {
             mode: 'cors',
             credentials: 'omit'
         }).then(response => response.json())
-            .catch(error => console.error(error))
 
         // collect all elements
         Main.getSubjects().forEach(e => {
@@ -323,7 +322,12 @@ class Main extends Logged {
             let link = null
             try {
                 link = subjectInfo["courses"][e[2]]["homepage"]
-            } catch (_) {}
+            } catch (_) { }
+            
+            // construct fallback URL
+            if (link === null && !["Překladače", "Nastavení", "FAQ"].includes(e[2])) {
+                link = "https://courses.fit.cvut.cz/" + e[2]
+            }
             
             push.innerHTML += `
 <a href="${e[1]}" class="subject" style="order: ${order}" pttorder="${order}">

--- a/src/content/end.js
+++ b/src/content/end.js
@@ -393,13 +393,14 @@ class Main extends Logged {
 
     static getSubjectIcon(title) {
         return ({
+            "BI-AAG": "icon-aag",
+            "BI-AG1": "icon-ag1",
+            "BI-OSY": "icon-osy",
             "BI-PA1": "icon-pa1",
             "BI-PA2": "icon-pa2",
-            "BI-PS1": "icon-ps1",
-            "BI-OSY": "icon-osy",
             "BI-PJV": "icon-pjv",
-            "BI-AG1": "icon-ag1",
-            "BI-AAG": "icon-aag"
+            "BI-PS1": "icon-ps1",
+            "BI-PYT": "icon-pyt"
         })[title] || "icon-unknown"
     }
 

--- a/src/themes/assets/icons/pyt.svg
+++ b/src/themes/assets/icons/pyt.svg
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   height="48"
+   id="svg6485"
+   version="1.1"
+   viewBox="0 0 48 48"
+   width="48"
+   sodipodi:docname="pyt.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1900"
+     inkscape:window-height="1018"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="17.125"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="1930"
+     inkscape:window-y="10"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="text250" />
+  <metadata
+     id="metadata246">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6487">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18427">
+      <rect
+         height="121.40158"
+         id="rect18429"
+         style="opacity:1;fill:#e9e9e9;fill-opacity:0.8041237;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke"
+         width="88.351334"
+         x="-269.08893"
+         y="204.7206" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18443">
+      <path
+         d="m -222.26758,211.43642 a 31.996582,31.996582 0 0 0 -31.99804,31.99609 31.996582,31.996582 0 0 0 10.67773,23.81446 c -3.77662,1.10404 -6.52344,4.57592 -6.52344,8.71875 0,5.03653 4.05527,9.09179 9.0918,9.09179 l 7.63086,0 0,35.49219 c 0,1.71385 1.3799,3.09375 3.09375,3.09375 1.71385,0 3.0918,-1.3799 3.0918,-3.09375 l 0,-35.49219 1.59179,0 0,37.99219 c 0,1.71385 1.3799,3.09375 3.09375,3.09375 1.71385,0 3.09375,-1.3799 3.09375,-3.09375 l 0,-37.99219 1.625,0 0,35.49219 c 0,1.71385 1.3799,3.09375 3.09375,3.09375 1.71385,0 3.09375,-1.3799 3.09375,-3.09375 l 0,-35.49219 6.67969,0 c 5.03653,0 9.0918,-4.05526 9.0918,-9.09179 0,-3.7665 -2.26947,-6.98211 -5.51954,-8.36524 a 31.996582,31.996582 0 0 0 11.0879,-24.16797 31.996582,31.996582 0 0 0 -31.9961,-31.99609 z"
+         id="path18445"
+         style="opacity:1;fill:#e9e9e9;fill-opacity:0.8041237;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:fill markers stroke" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5172">
+      <rect
+         height="32"
+         id="rect5174"
+         rx="0"
+         ry="0"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.51572331;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         width="32"
+         x="0"
+         y="1020.3622" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5284">
+      <rect
+         height="48"
+         id="rect5286"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.48427675;fill-rule:nonzero;stroke:none;stroke-width:0.40000001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         width="48"
+         x="0"
+         y="1004.3622" />
+    </clipPath>
+  </defs>
+  <g
+     id="layer1"
+     style="display:inline"
+     transform="translate(0,-1004.3622)">
+    <g
+       id="g11377"
+       style="display:inline"
+       transform="translate(-677.0004,-105.9995)">
+      <path
+         d="m 703,1112.3622 c -0.554,0 -1,0.446 -1,1 l 0,1 c 0,0.554 0.446,1 1,1 l 10.0039,0 0.016,6.4844 c 0,0.8253 0.6708,1.4938 1.4961,1.4961 l 6.4844,0.017 0,28.502 c 0,0.8569 -0.6431,1.5 -1.5,1.5 l -23,0 c -0.857,0 -1.5,-0.6431 -1.5,-1.5 l 0,-1.5 c 0,-0.554 -0.446,-1 -1,-1 l -1,0 c -0.554,0 -1,0.446 -1,1 l 0,1.5 c 0,2.4671 2.0329,4.5 4.5,4.5 l 23,0 c 2.467,0 4.5,-2.0329 4.5,-4.5 l 0,-30.4863 c -10e-5,-0.3978 -0.1582,-0.7793 -0.4395,-1.0606 l -7.5137,-7.5136 c -0.2812,-0.2814 -0.6627,-0.4394 -1.0605,-0.4395 z m -11,21 c 0,0.554 0.446,1 1,1 l 1,0 c 0.554,0 1,-0.446 1,-1 l 0,-10 c 0,-0.554 -0.446,-1 -1,-1 l -1,0 c -0.554,0 -1,0.446 -1,1 z"
+         id="path8766"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#242730;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         d="m 696.5,108 c -2.467,0 -4.5,2.0329 -4.5,4.5 v 2.5 c 0,0.554 0.446,1 1,1 h 1 c 0.554,0 1,-0.446 1,-1 v -2.5 c 0,-0.8569 0.6431,-1.5 1.5,-1.5 h 2.5 c 0.554,0 1,-0.446 1,-1 v -1 c 0,-0.554 -0.446,-1 -1,-1 z M 681,132 c -1.10801,0 -2,0.892 -2,2 v 7 c 0,1.108 0.89199,2 2,2 h 25 c 1.10801,0 2,-0.892 2,-2 v -7 c 0,-1.108 -0.89199,-2 -2,-2 z m 15.03929,7.27539 c -12.69259,-22.18393 -6.3463,-11.09196 0,0 z"
+         id="path8768"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#11c111;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         transform="translate(0,1004.3622)" />
+      <g
+         aria-label="PY"
+         id="text250"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.6667px;line-height:1.25;font-family:'Courier New';-inkscape-font-specification:'Courier New Bold';fill:#ffffff">
+        <path
+           d="m 690.20048,1142.6488 v 0.9888 h 0.97001 q 0.34677,0 0.49203,0.1358 0.14995,0.1313 0.14995,0.3469 0,0.2108 -0.14995,0.3467 -0.14526,0.1312 -0.49203,0.1312 h -2.08061 q -0.34676,0 -0.49671,-0.1312 -0.14527,-0.1359 -0.14527,-0.3515 0,-0.2108 0.14995,-0.3421 0.14995,-0.1358 0.49203,-0.1358 h 0.14996 v -3.7582 h -0.14996 q -0.34676,0 -0.49671,-0.1313 -0.14527,-0.136 -0.14527,-0.3515 0,-0.2155 0.14527,-0.3468 0.14995,-0.1358 0.49671,-0.1358 l 2.21181,0.01 q 0.9747,0 1.54171,0.5341 0.5717,0.5297 0.5717,1.2935 0,0.4217 -0.19212,0.7967 -0.14527,0.2811 -0.48735,0.5576 -0.3374,0.2717 -0.69354,0.4123 -0.35145,0.1359 -0.93252,0.1359 z m 0,-0.9606 h 0.89035 q 0.62793,0 0.99344,-0.2812 0.37019,-0.2858 0.37019,-0.6842 0,-0.3373 -0.29991,-0.5904 -0.29521,-0.253 -0.84817,-0.253 h -1.1059 z"
+           id="path29"
+           style="stroke-width:0.899722" />
+        <path
+           d="m 696.99993,1142.2131 v 1.4245 h 0.64667 q 0.34677,0 0.49203,0.1358 0.14995,0.1313 0.14995,0.3469 0,0.2108 -0.14995,0.3467 -0.14526,0.1312 -0.49203,0.1312 h -2.25399 q -0.34208,0 -0.49203,-0.1312 -0.14527,-0.1359 -0.14527,-0.3515 0,-0.2108 0.14527,-0.3421 0.14995,-0.1358 0.49203,-0.1358 h 0.64668 v -1.4245 l -1.58857,-2.3337 q -0.31865,0 -0.46861,-0.136 -0.14527,-0.1359 -0.14527,-0.3468 0,-0.2155 0.14527,-0.3468 0.14996,-0.1358 0.49673,-0.1358 l 0.8716,0.01 q 0.34677,0 0.49204,0.1311 0.14994,0.1313 0.14994,0.3468 0,0.3233 -0.37956,0.4828 l 0.90909,1.3402 0.89034,-1.3402 q -0.21086,-0.08 -0.2999,-0.2017 -0.0891,-0.1218 -0.0891,-0.2811 0,-0.2155 0.14527,-0.3468 0.14995,-0.1311 0.49671,-0.1358 l 0.90442,0.01 q 0.34676,0 0.49202,0.1312 0.14996,0.1312 0.14996,0.3467 0,0.2156 -0.14996,0.3515 -0.14995,0.1313 -0.48735,0.1313 z"
+           id="path31"
+           style="stroke-width:0.899722" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/src/themes/common.css
+++ b/src/themes/common.css
@@ -655,28 +655,36 @@ div.subjectSelect > span.subjectHeader.active:before {
     top: 14px;
 }
 
-.icon-pa2 {
-    background-image: url('./assets/icons/pa2.svg')
-}
-
-.icon-pa1 {
-    background-image: url('./assets/icons/pa1.svg')
-}
-
-.icon-ps1 {
-    background-image: url('./assets/icons/ps1.svg')
-}
-
-.icon-pjv {
-    background-image: url('./assets/icons/pjv.svg')
+.icon-aag {
+    background-image: url('./assets/icons/aag.svg')
 }
 
 .icon-ag1 {
     background-image: url('./assets/icons/ag1.svg')
 }
 
-.icon-aag {
-    background-image: url('./assets/icons/aag.svg')
+.icon-osy {
+    background-image: url('./assets/icons/osy.svg');
+}
+
+.icon-pa1 {
+    background-image: url('./assets/icons/pa1.svg')
+}
+
+.icon-pa2 {
+    background-image: url('./assets/icons/pa2.svg')
+}
+
+.icon-pjv {
+    background-image: url('./assets/icons/pjv.svg')
+}
+
+.icon-ps1 {
+    background-image: url('./assets/icons/ps1.svg')
+}
+
+.icon-pyt {
+    background-image: url('./assets/icons/pyt.svg')
 }
 
 .icon-setting {
@@ -689,10 +697,6 @@ div.subjectSelect > span.subjectHeader.active:before {
 
 .icon-compile {
     background-image: url('./assets/icons/compile.svg');
-}
-
-.icon-osy {
-    background-image: url('./assets/icons/osy.svg');
 }
 
 .icon-unknown {


### PR DESCRIPTION
I'm submitting this as a PR since it is quite a big change, not in LOC, but in the fact that it requires one extra permission (and IIRC that shows as a pop-up for all users).

Beforehand, subject URLs were hardcoded, this PR changes it so that the extension requests data that the [Courses Signpost](https://courses.fit.cvut.cz/) uses and finds out the subject URL from that. This JSON file is being updated regularly and contains the link to the subject homepage for the current semester, if there is one (whether it's on Courses, Moodle, or somewhere else). In order to send the request, I had to put most of the constructor of `Main` into a separate async function, since sending web requests on the main thread is deprecated for quite some time. 

As for why the extra permission: This doesn't work without it in Firefox, since Firefox extensions can only send requests to the sites that they have permissions for (unlike Chrome, where this worked flawlessly). I added the extra permission to manifests to both browsers, just in case Chrome changes it to work in line with Firefox.

I can merge it, I'd just like to know whether the one extra permission is a big deal or not.