### PR TITLE
Add automatic theme

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,5 +1,5 @@
 
-var theme = 'light';
+var theme = 'automatic';
 var dropdown = true
 var displayNotifications = true
 var highlighting = true
@@ -7,7 +7,7 @@ var sounds = true
 
 const updateConfig = () => {
     chrome.storage.sync.get({
-        selectedTheme: 'light',
+        selectedTheme: 'automatic',
         autoHide: true,
         notifications: true,
         highlighting: true,
@@ -42,7 +42,18 @@ chrome.webRequest.onBeforeRequest.addListener(
     () => {
         if (theme == 'orig')
             {return { cancel: false };}
-        return { redirectUrl: chrome.runtime.getURL('themes/' + theme + '.css') };
+        let themeName;
+        if (theme === 'automatic') {
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                themeName = 'dark'
+            } else {
+                // light theme is the fallback if prefers-color-scheme doesn't work
+                themeName = 'light'
+            }
+        } else {
+            themeName = theme
+        }
+        return { redirectUrl: chrome.runtime.getURL('themes/' + themeName + '.css') };
     },
     { urls: ["*://progtest.fit.cvut.cz/css.css", "*://ptmock.localhost/css.css"] },
     ["blocking"]

--- a/src/background.js
+++ b/src/background.js
@@ -42,18 +42,7 @@ chrome.webRequest.onBeforeRequest.addListener(
     () => {
         if (theme == 'orig')
             {return { cancel: false };}
-        let themeName;
-        if (theme === 'automatic') {
-            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                themeName = 'dark'
-            } else {
-                // light theme is the fallback if prefers-color-scheme doesn't work
-                themeName = 'light'
-            }
-        } else {
-            themeName = theme
-        }
-        return { redirectUrl: chrome.runtime.getURL('themes/' + themeName + '.css') };
+        return { redirectUrl: chrome.runtime.getURL('themes/' + theme + '.css') };
     },
     { urls: ["*://progtest.fit.cvut.cz/css.css", "*://ptmock.localhost/css.css"] },
     ["blocking"]

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -63,6 +63,7 @@ Select your theme
   <option value="orig-dark">Original Dark</option> 
   <option value="light">Light</option>
   <option value="dark">Dark</option>
+  <option value="automatic">Automatic</option>
 </select>
 <br />
   <table class="dropdown_c" id="config">

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -35,7 +35,7 @@ function save_options() {
 
 function restore_options() {
   chrome.storage.sync.get({
-    selectedTheme: 'light',
+    selectedTheme: 'automatic',
     autoHide: true,
     notifications: true,
     highlighting: true,

--- a/src/themes/automatic.css
+++ b/src/themes/automatic.css
@@ -1,0 +1,2 @@
+@import url("./dark.css") (prefers-color-scheme: dark);
+@import url("./light.css") (prefers-color-scheme: light);


### PR DESCRIPTION
This adds a new theme - automatic - and sets it as the default. This theme should respect the `prefers-color-scheme` CSS attribute, meaning that the theme (light/dark) depends on the OS theme.

Tested on: 
* Mozilla Firefox Developer Edition 88.0b8 on Arch Linux - working (tried light and dark GTK themes)
* Chromium 89.0.4389.114 on Arch Linux - working* (but a bug in Chromium means `prefers-color-scheme` is always `light` on Linux, unless using the `--force-dark-theme` launch parameter)
* Mozilla Firefox 87.0 on Windows 10 (21H1, build 19043) - working
* Microsoft Edge 89.0.774.68 on Windows 10 (21H1, build 19043) - working